### PR TITLE
Black Home Page for Dark Theme

### DIFF
--- a/themes/_spiked.scss
+++ b/themes/_spiked.scss
@@ -81,3 +81,8 @@ background: #212121 !important;
 .downloads_Button_3oavR.DialogButton:enabled {
 background: #3f3f3f !important;
 }
+
+/* Black Home Page/Library/Shelf Background*/
+.libraryhome_Container_2gSXC {
+	background-color: #0c0c0c;
+}


### PR DESCRIPTION
Makes background for Home Page black instead of Steam's default gray.

Is this how to github? If not oh well. Feel free to do w/e with this. It's mostly intended for me so I don't forget in the future.